### PR TITLE
Ajoute la suppression animée des tâches avec persistance locale

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -152,6 +152,7 @@ ul {
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .tache-item h3 {
@@ -186,6 +187,23 @@ ul {
   cursor: pointer;
 }
 
+.bouton-suppression {
+  background: transparent;
+  border: 1px solid #ef4444;
+  color: #fca5a5;
+  padding: 0.4em 0.8em;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.bouton-suppression:hover {
+  background: #ef4444;
+  color: #fff;
+  transform: translateY(-1px);
+}
+
 .tache-terminee {
   opacity: 0.7;
 }
@@ -193,6 +211,24 @@ ul {
 .tache-terminee h3,
 .tache-terminee p {
   text-decoration: line-through;
+}
+
+.tache-suppression {
+  animation: disparitionTache 0.35s ease forwards;
+}
+
+@keyframes disparitionTache {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  40% {
+    transform: translateY(-6px) scale(1.02);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(12px) scale(0.95);
+  }
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Résumé
- ajoute un identifiant unique aux tâches et les persiste dans le localStorage du navigateur
- ajoute un bouton de suppression animé pour retirer les tâches avec une transition visuelle
- met à jour le style de l’en-tête des tâches et du bouton de suppression

## Tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df9e012f788332b724f3b31cfb32e7