### PR TITLE
feat: permettre l'édition des tâches et afficher des compteurs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -75,6 +75,38 @@ h2 {
   margin-bottom: 1.5rem;
 }
 
+.resume-taches {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin: 1.5rem 0 0.5rem 0;
+}
+
+.carte-resume {
+  background: #1a1a20;
+  border-radius: 12px;
+  padding: 0.9rem 1.4rem;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: inset 0 1px 0 #ffffff08, 0 8px 20px #00000033;
+}
+
+.resume-titre {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a1a1aa;
+}
+
+.resume-valeur {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #c7d2fe;
+}
+
 form {
   display: flex;
   flex-direction: column;
@@ -155,6 +187,12 @@ ul {
   flex-wrap: wrap;
 }
 
+.actions-tache {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .tache-item h3 {
   margin: 0 0 0.3rem 0;
   font-size: 1.2rem;
@@ -196,12 +234,93 @@ ul {
   border-radius: 6px;
   box-shadow: none;
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  margin-top: 0;
 }
 
 .bouton-suppression:hover {
   background: #ef4444;
   color: #fff;
   transform: translateY(-1px);
+}
+
+.bouton-edition {
+  background: transparent;
+  border: 1px solid #6366f1;
+  color: #c7d2fe;
+  padding: 0.4em 0.8em;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  box-shadow: none;
+  margin-top: 0;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.bouton-edition:hover {
+  background: #4f46e5;
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.bouton-secondaire {
+  background: transparent;
+  border: 1px solid #71717a;
+  color: #e4e4e7;
+  padding: 0.55em 1em;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  margin-top: 0;
+  box-shadow: none;
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.bouton-secondaire:hover {
+  border-color: #a1a1aa;
+  color: #fafafa;
+  transform: translateY(-1px);
+}
+
+.bouton-secondaire:disabled,
+.bouton-edition:disabled,
+.bouton-suppression:disabled,
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.edition-tache {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.edition-entete {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.statut-edition {
+  justify-content: flex-end;
+}
+
+.edition-champs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.edition-champs label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: #d4d4d8;
+}
+
+.edition-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
 }
 
 .tache-terminee {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,10 @@ function App() {
     }
   });
   const [enSuppression, setEnSuppression] = useState<Array<string>>([]);
+  const [idEnEdition, setIdEnEdition] = useState<string | null>(null);
+  const [titreEdition, setTitreEdition] = useState("");
+  const [descriptionEdition, setDescriptionEdition] = useState("");
+  const [dateEcheanceEdition, setDateEcheanceEdition] = useState("");
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -52,8 +56,8 @@ function App() {
     event.preventDefault();
     const nouvelleTache: Tache = {
       id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
-      titre,
-      description,
+      titre: titre.trim(),
+      description: description.trim(),
       dateEcheance,
       terminee: false,
     };
@@ -64,10 +68,10 @@ function App() {
     setDateEcheance("");
   }
 
-  function basculerEtatTache(index: number) {
+  function basculerEtatTache(id: string) {
     setListe((taches) =>
-      taches.map((tache, position) =>
-        position === index ? { ...tache, terminee: !tache.terminee } : tache
+      taches.map((tache) =>
+        tache.id === id ? { ...tache, terminee: !tache.terminee } : tache
       )
     );
   }
@@ -88,10 +92,56 @@ function App() {
     });
   }
 
+  function demarrerEdition(tache: Tache) {
+    setIdEnEdition(tache.id);
+    setTitreEdition(tache.titre);
+    setDescriptionEdition(tache.description);
+    setDateEcheanceEdition(tache.dateEcheance);
+  }
+
+  function annulerEdition() {
+    setIdEnEdition(null);
+    setTitreEdition("");
+    setDescriptionEdition("");
+    setDateEcheanceEdition("");
+  }
+
+  function enregistrerEdition(id: string) {
+    if (!titreEdition.trim()) {
+      return;
+    }
+    setListe((taches) =>
+      taches.map((tache) =>
+        tache.id === id
+          ? {
+              ...tache,
+              titre: titreEdition.trim(),
+              description: descriptionEdition.trim(),
+              dateEcheance: dateEcheanceEdition,
+            }
+          : tache
+      )
+    );
+    annulerEdition();
+  }
+
+  const nombreTerminees = liste.filter((tache) => tache.terminee).length;
+  const nombreAFaire = liste.length - nombreTerminees;
+
   return (
     <div>
       <h1>Bonjour 👋</h1>
       <h2>Voici un formulaire de to-do list</h2>
+      <div className="resume-taches">
+        <div className="carte-resume">
+          <span className="resume-titre">À faire</span>
+          <span className="resume-valeur">{nombreAFaire}</span>
+        </div>
+        <div className="carte-resume">
+          <span className="resume-titre">Terminées</span>
+          <span className="resume-valeur">{nombreTerminees}</span>
+        </div>
+      </div>
       <div className="main-layout">
         <div className="form-col">
           <form action="#">
@@ -124,7 +174,7 @@ function App() {
         <div className="taches-list">
           <h2>Liste des tâches</h2>
           <ul>
-            {liste.map((tache, index) => (
+            {liste.map((tache) => (
               <li
                 className={`tache-item ${
                   tache.terminee ? "tache-terminee" : ""
@@ -132,27 +182,103 @@ function App() {
                 key={tache.id}
                 onAnimationEnd={() => gererFinSuppression(tache.id)}
               >
-                <div className="tache-en-tete">
-                  <h3>{tache.titre}</h3>
-                  <label className="statut-tache">
-                    <input
-                      type="checkbox"
-                      checked={tache.terminee}
-                      onChange={() => basculerEtatTache(index)}
-                    />
-                    <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
-                  </label>
-                  <button
-                    type="button"
-                    className="bouton-suppression"
-                    onClick={() => supprimerTache(tache.id)}
-                    aria-label={`Supprimer la tâche ${tache.titre}`}
-                  >
-                    Supprimer
-                  </button>
-                </div>
-                <p>Description : {tache.description}</p>
-                <p className="date">Date d'échéance : {tache.dateEcheance}</p>
+                {idEnEdition === tache.id ? (
+                  <div className="edition-tache">
+                    <div className="edition-entete">
+                      <label className="statut-tache statut-edition">
+                        <input
+                          type="checkbox"
+                          checked={tache.terminee}
+                          onChange={() => basculerEtatTache(tache.id)}
+                        />
+                        <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
+                      </label>
+                    </div>
+                    <div className="edition-champs">
+                      <label>
+                        <span>Titre</span>
+                        <input
+                          type="text"
+                          value={titreEdition}
+                          onChange={(event) => setTitreEdition(event.target.value)}
+                          required
+                        />
+                      </label>
+                      <label>
+                        <span>Description</span>
+                        <input
+                          type="text"
+                          value={descriptionEdition}
+                          onChange={(event) =>
+                            setDescriptionEdition(event.target.value)
+                          }
+                        />
+                      </label>
+                      <label>
+                        <span>Date d'échéance</span>
+                        <input
+                          type="date"
+                          value={dateEcheanceEdition}
+                          onChange={(event) =>
+                            setDateEcheanceEdition(event.target.value)
+                          }
+                        />
+                      </label>
+                    </div>
+                    <div className="edition-actions">
+                      <button
+                        type="button"
+                        onClick={() => enregistrerEdition(tache.id)}
+                        disabled={!titreEdition.trim()}
+                      >
+                        Enregistrer
+                      </button>
+                      <button
+                        type="button"
+                        className="bouton-secondaire"
+                        onClick={annulerEdition}
+                      >
+                        Annuler
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="tache-en-tete">
+                      <h3>{tache.titre}</h3>
+                      <div className="actions-tache">
+                        <label className="statut-tache">
+                          <input
+                            type="checkbox"
+                            checked={tache.terminee}
+                            onChange={() => basculerEtatTache(tache.id)}
+                          />
+                          <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
+                        </label>
+                        <button
+                          type="button"
+                          className="bouton-edition"
+                          onClick={() => demarrerEdition(tache)}
+                          aria-label={`Modifier la tâche ${tache.titre}`}
+                        >
+                          Modifier
+                        </button>
+                        <button
+                          type="button"
+                          className="bouton-suppression"
+                          onClick={() => supprimerTache(tache.id)}
+                          aria-label={`Supprimer la tâche ${tache.titre}`}
+                        >
+                          Supprimer
+                        </button>
+                      </div>
+                    </div>
+                    <p>Description : {tache.description || "Aucune description"}</p>
+                    <p className="date">
+                      Date d'échéance : {tache.dateEcheance || "Non définie"}
+                    </p>
+                  </>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Résumé
- ajoute une vue récapitulative du nombre de tâches à faire et terminées en tête de page
- permet de modifier une tâche existante via un formulaire inline avec validations basées sur le titre
- améliore le style des actions de tâche et des boutons d’édition/annulation

## Tests
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dfaddbd6848332946af7a156c39494