### PR TITLE
docs: réécrire le README du projet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,71 @@
-# React + TypeScript + Vite
+# Gestionnaire de tâches – React + TypeScript + Vite
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Ce dépôt contient une application de to-do list moderne développée avec React 19, TypeScript et Vite. L'interface met l'accent sur l'accessibilité, les animations CSS et la persistance locale des données pour offrir une expérience utilisateur fluide.
 
-Currently, two official plugins are available:
+## Aperçu fonctionnel
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **Création de tâches** : formulaire guidé pour saisir un titre, une description optionnelle et une date d'échéance.
+- **Gestion de l'état** : suivi des tâches « À faire » et « Terminées » avec compteurs animés.
+- **Persistance locale** : stockage automatique des tâches dans `localStorage` afin de conserver la liste entre les sessions de navigation.
+- **Modification en ligne** : édition d'une tâche existante avec validation du titre et mise à jour instantanée.
+- **Achèvement rapide** : case à cocher pour marquer une tâche comme réalisée ou la remettre « À faire ».
+- **Suppression sécurisée** : fenêtre modale de confirmation et animation de disparition avant retrait de la tâche.
+- **Animations soignées** : transitions pour l'ajout et la suppression, effets de cartes flottantes et mise en valeur du contexte.
 
-## React Compiler
+## Prérequis
 
-The React Compiler is enabled on this template. See [this documentation](https://react.dev/learn/react-compiler) for more information.
+- [Node.js](https://nodejs.org/) **>= 18** (recommandé pour profiter du support officiel de Vite 7 et de React 19).
+- [npm](https://www.npmjs.com/) (fourni avec Node.js).
 
-Note: This will impact Vite dev & build performances.
+## Installation
 
-## Expanding the ESLint configuration
+1. Installer les dépendances du projet :
+   ```bash
+   npm install
+   ```
+2. Lancer le serveur de développement (avec rechargement à chaud) :
+   ```bash
+   npm run dev
+   ```
+   Par défaut, Vite démarre sur [http://localhost:5173](http://localhost:5173).
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## Scripts npm disponibles
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+| Commande | Description |
+| --- | --- |
+| `npm run dev` | Démarre le serveur de développement Vite. |
+| `npm run build` | Compile l'application en production (`dist/`) après vérification TypeScript. |
+| `npm run preview` | Sert localement la version buildée. |
+| `npm run lint` | Analyse le projet avec ESLint et les règles React/TypeScript configurées. |
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+## Structure du projet
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+├── public/                # Fichiers statiques servis tels quels
+├── src/
+│   ├── App.tsx            # Composant principal et logique métier (CRUD, animations, stockage)
+│   ├── App.css            # Styles principaux et animations personnalisées
+│   ├── main.tsx           # Point d'entrée React + création du root
+│   ├── index.css          # Styles globaux et variables CSS
+│   └── assets/            # Ressources supplémentaires (si nécessaire)
+├── package.json           # Dépendances et scripts npm
+├── tsconfig*.json         # Configuration TypeScript (app & outils)
+└── vite.config.ts         # Configuration Vite et plugin React
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Qualité et bonnes pratiques
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- **TypeScript strict** : typage fort (`Tache`) pour sécuriser la manipulation des données.
+- **React Compiler** : activé par défaut via `babel-plugin-react-compiler` pour optimiser le rendu.
+- **Stockage défensif** : parsing JSON encapsulé avec gestion des erreurs pour éviter les données corrompues.
+- **Accessibilité** : modale avec attributs ARIA, libellés explicites et gestion du focus via React.
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+## Aller plus loin
+
+- Personnaliser la feuille de style (`src/App.css`) pour ajuster la charte graphique.
+- Connecter une API distante en remplaçant la persistance locale par des appels réseau.
+- Ajouter des tests (par exemple avec Vitest ou Jest) afin d'automatiser la validation fonctionnelle.
+
+---
+
+Ce projet peut servir de base pour une application de gestion personnelle ou être enrichi pour couvrir des usages collaboratifs.


### PR DESCRIPTION
## Résumé
- réécriture complète du README pour présenter l’application de to-do list et ses fonctionnalités
- ajout des sections d’installation, scripts disponibles, structure du projet et axes d’amélioration

## Tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb91745a08332870eb7862097e0e0