### PR TITLE
Refactor: organiser l'interface de la todo en composants dédiés

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,12 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { MouseEvent } from "react";
 import "./App.css";
-
-type Tache = {
-  id: string;
-  titre: string;
-  description: string;
-  dateEcheance: string;
-  terminee: boolean;
-};
+import { FormulaireTache } from "./components/FormulaireTache";
+import { ResumeTaches } from "./components/ResumeTaches";
+import { FiltresTaches } from "./components/FiltresTaches";
+import { ListeTaches } from "./components/ListeTaches";
+import { ModalConfirmation } from "./components/ModalConfirmation";
+import type { FiltreTache, Tache } from "./types/tache";
 
 function App() {
   const [titre, setTitre] = useState("");
@@ -50,9 +49,7 @@ function App() {
   );
   const [animeCompteurAFaire, setAnimeCompteurAFaire] = useState(false);
   const [animeCompteurTerminees, setAnimeCompteurTerminees] = useState(false);
-  const [filtreActif, setFiltreActif] = useState<"toutes" | "aFaire" | "terminees">(
-    "toutes"
-  );
+  const [filtreActif, setFiltreActif] = useState<FiltreTache>("toutes");
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -61,7 +58,7 @@ function App() {
     window.localStorage.setItem("taches", JSON.stringify(liste));
   }, [liste]);
 
-  function addTache(event: React.MouseEvent<HTMLButtonElement>) {
+  function addTache(event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     const nouvelleTache: Tache = {
       id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -99,9 +96,7 @@ function App() {
       return;
     }
     const id = tacheASupprimer.id;
-    setEnSuppression((ids) =>
-      ids.includes(id) ? ids : [...ids, id]
-    );
+    setEnSuppression((ids) => (ids.includes(id) ? ids : [...ids, id]));
     setTacheASupprimer(null);
   }
 
@@ -198,10 +193,7 @@ function App() {
 
   useEffect(() => {
     setAnimeCompteurTerminees(true);
-    const timer = window.setTimeout(
-      () => setAnimeCompteurTerminees(false),
-      600
-    );
+    const timer = window.setTimeout(() => setAnimeCompteurTerminees(false), 600);
     return () => window.clearTimeout(timer);
   }, [nombreTerminees]);
 
@@ -209,242 +201,61 @@ function App() {
     <div>
       <h1>Bonjour 👋</h1>
       <h2>Voici un formulaire de to-do list</h2>
-      <div className="resume-taches">
-        <div className="carte-resume carte-animable">
-          <span className="resume-titre">À faire</span>
-          <span
-            className={`resume-valeur ${
-              animeCompteurAFaire ? "compteur-anime" : ""
-            }`}
-          >
-            {nombreAFaire}
-          </span>
-        </div>
-        <div className="carte-resume carte-animable">
-          <span className="resume-titre">Terminées</span>
-          <span
-            className={`resume-valeur ${
-              animeCompteurTerminees ? "compteur-anime" : ""
-            }`}
-          >
-            {nombreTerminees}
-          </span>
-        </div>
-      </div>
+      <ResumeTaches
+        nombreAFaire={nombreAFaire}
+        nombreTerminees={nombreTerminees}
+        animeCompteurAFaire={animeCompteurAFaire}
+        animeCompteurTerminees={animeCompteurTerminees}
+      />
       <div className="main-layout">
-        <div className="form-col bloc-animable">
-          <form action="#">
-            <p>Titre de la tache</p>
-            <input
-              type="text"
-              placeholder="Titre"
-              value={titre}
-              onChange={(e) => setTitre(e.target.value)}
-              required
-            />
-            <p>Description de la tache</p>
-            <input
-              type="text"
-              placeholder="Description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-            <p>Date d'échéance</p>
-            <input
-              type="date"
-              value={dateEcheance}
-              onChange={(e) => setDateEcheance(e.target.value)}
-            />
-            {titre && (
-              <button onClick={addTache}>Ajouter</button>
-            )}
-          </form>
-        </div>
+        <FormulaireTache
+          titre={titre}
+          description={description}
+          dateEcheance={dateEcheance}
+          onTitreChange={setTitre}
+          onDescriptionChange={setDescription}
+          onDateEcheanceChange={setDateEcheance}
+          onAjouter={addTache}
+        />
         <div className="taches-list bloc-animable">
           <h2>Liste des tâches</h2>
-          <div className="filtres-taches" role="group" aria-label="Filtres des tâches">
-            <button
-              type="button"
-              className={`filtre-bouton ${filtreActif === "toutes" ? "actif" : ""}`}
-              onClick={() => setFiltreActif("toutes")}
-              aria-pressed={filtreActif === "toutes"}
-            >
-              Toutes
-            </button>
-            <button
-              type="button"
-              className={`filtre-bouton ${filtreActif === "aFaire" ? "actif" : ""}`}
-              onClick={() => setFiltreActif("aFaire")}
-              aria-pressed={filtreActif === "aFaire"}
-            >
-              À faire
-            </button>
-            <button
-              type="button"
-              className={`filtre-bouton ${filtreActif === "terminees" ? "actif" : ""}`}
-              onClick={() => setFiltreActif("terminees")}
-              aria-pressed={filtreActif === "terminees"}
-            >
-              Terminées
-            </button>
-          </div>
+          <FiltresTaches
+            filtreActif={filtreActif}
+            onFiltreChange={setFiltreActif}
+          />
           {listeFiltree.length === 0 ? (
             <p className="liste-vide">{messageAucunResultat}</p>
           ) : (
-            <ul>
-              {listeFiltree.map((tache) => (
-              <li
-                className={`tache-item ${
-                  tache.terminee ? "tache-terminee" : ""
-                } ${
-                  enSuppression.includes(tache.id) ? "tache-suppression" : ""
-                } ${derniereTacheAjoutee === tache.id ? "tache-ajout" : ""}`}
-                key={tache.id}
-                onAnimationEnd={(event) =>
-                  gererFinSuppression(tache.id, event.animationName)
-                }
-              >
-                {idEnEdition === tache.id ? (
-                  <div className="edition-tache">
-                    <div className="edition-entete">
-                      <label className="statut-tache statut-edition">
-                        <input
-                          type="checkbox"
-                          checked={tache.terminee}
-                          onChange={() => basculerEtatTache(tache.id)}
-                        />
-                        <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
-                      </label>
-                    </div>
-                    <div className="edition-champs">
-                      <label>
-                        <span>Titre</span>
-                        <input
-                          type="text"
-                          value={titreEdition}
-                          onChange={(event) => setTitreEdition(event.target.value)}
-                          required
-                        />
-                      </label>
-                      <label>
-                        <span>Description</span>
-                        <input
-                          type="text"
-                          value={descriptionEdition}
-                          onChange={(event) =>
-                            setDescriptionEdition(event.target.value)
-                          }
-                        />
-                      </label>
-                      <label>
-                        <span>Date d'échéance</span>
-                        <input
-                          type="date"
-                          value={dateEcheanceEdition}
-                          onChange={(event) =>
-                            setDateEcheanceEdition(event.target.value)
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="edition-actions">
-                      <button
-                        type="button"
-                        onClick={() => enregistrerEdition(tache.id)}
-                        disabled={!titreEdition.trim()}
-                      >
-                        Enregistrer
-                      </button>
-                      <button
-                        type="button"
-                        className="bouton-secondaire"
-                        onClick={annulerEdition}
-                      >
-                        Annuler
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <div className="tache-en-tete">
-                      <h3>{tache.titre}</h3>
-                      <div className="actions-tache">
-                        <label className="statut-tache">
-                          <input
-                            type="checkbox"
-                            checked={tache.terminee}
-                            onChange={() => basculerEtatTache(tache.id)}
-                          />
-                          <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
-                        </label>
-                        <button
-                          type="button"
-                          className="bouton-edition"
-                          onClick={() => demarrerEdition(tache)}
-                          aria-label={`Modifier la tâche ${tache.titre}`}
-                        >
-                          Modifier
-                        </button>
-                        <button
-                          type="button"
-                          className="bouton-suppression"
-                          onClick={() => supprimerTache(tache.id)}
-                          aria-label={`Supprimer la tâche ${tache.titre}`}
-                        >
-                          Supprimer
-                        </button>
-                      </div>
-                    </div>
-                    <p>Description : {tache.description || "Aucune description"}</p>
-                    <p className="date">
-                      Date d'échéance : {tache.dateEcheance || "Non définie"}
-                    </p>
-                  </>
-                )}
-              </li>
-              ))}
-            </ul>
+            <ListeTaches
+              taches={listeFiltree}
+              enSuppression={enSuppression}
+              derniereTacheAjoutee={derniereTacheAjoutee}
+              idEnEdition={idEnEdition}
+              titreEdition={titreEdition}
+              descriptionEdition={descriptionEdition}
+              dateEcheanceEdition={dateEcheanceEdition}
+              onTitreEditionChange={setTitreEdition}
+              onDescriptionEditionChange={setDescriptionEdition}
+              onDateEcheanceEditionChange={setDateEcheanceEdition}
+              onBasculerEtat={basculerEtatTache}
+              onDemarrerEdition={demarrerEdition}
+              onAnnulerEdition={annulerEdition}
+              onEnregistrerEdition={enregistrerEdition}
+              onSupprimerTache={supprimerTache}
+              onFinSuppression={gererFinSuppression}
+            />
           )}
         </div>
       </div>
-    {tacheASupprimer && (
-      <div
-        className="modal-overlay"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="confirmation-suppression-titre"
-        onClick={annulerSuppressionTache}
-      >
-        <div
-          className="modal-content"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <h3 id="confirmation-suppression-titre">Confirmer la suppression</h3>
-          <p>
-            Voulez-vous vraiment supprimer la tache{" "}
-            <strong>{tacheASupprimer.titre || "sans titre"}</strong> ?
-          </p>
-          <div className="modal-actions">
-            <button
-              type="button"
-              className="bouton-suppression"
-              onClick={confirmerSuppressionTache}
-            >
-              Supprimer
-            </button>
-            <button
-              type="button"
-              className="bouton-secondaire"
-              onClick={annulerSuppressionTache}
-            >
-              Annuler
-            </button>
-          </div>
-        </div>
-      </div>
-    )}
+      {tacheASupprimer && (
+        <ModalConfirmation
+          tache={tacheASupprimer}
+          onConfirmer={confirmerSuppressionTache}
+          onAnnuler={annulerSuppressionTache}
+        />
+      )}
     </div>
-
   );
 }
+
 export default App;

--- a/src/components/FiltresTaches.tsx
+++ b/src/components/FiltresTaches.tsx
@@ -1,0 +1,30 @@
+import type { FiltreTache } from "../types/tache";
+
+type FiltresTachesProps = {
+  filtreActif: FiltreTache;
+  onFiltreChange: (filtre: FiltreTache) => void;
+};
+
+const libelles: Record<FiltreTache, string> = {
+  toutes: "Toutes",
+  aFaire: "À faire",
+  terminees: "Terminées",
+};
+
+export function FiltresTaches({ filtreActif, onFiltreChange }: FiltresTachesProps) {
+  return (
+    <div className="filtres-taches" role="group" aria-label="Filtres des tâches">
+      {(Object.keys(libelles) as Array<FiltreTache>).map((filtre) => (
+        <button
+          key={filtre}
+          type="button"
+          className={`filtre-bouton ${filtreActif === filtre ? "actif" : ""}`}
+          onClick={() => onFiltreChange(filtre)}
+          aria-pressed={filtreActif === filtre}
+        >
+          {libelles[filtre]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/FormulaireTache.tsx
+++ b/src/components/FormulaireTache.tsx
@@ -1,0 +1,50 @@
+import type { MouseEvent } from "react";
+
+type FormulaireTacheProps = {
+  titre: string;
+  description: string;
+  dateEcheance: string;
+  onTitreChange: (valeur: string) => void;
+  onDescriptionChange: (valeur: string) => void;
+  onDateEcheanceChange: (valeur: string) => void;
+  onAjouter: (event: MouseEvent<HTMLButtonElement>) => void;
+};
+
+export function FormulaireTache({
+  titre,
+  description,
+  dateEcheance,
+  onTitreChange,
+  onDescriptionChange,
+  onDateEcheanceChange,
+  onAjouter,
+}: FormulaireTacheProps) {
+  return (
+    <div className="form-col bloc-animable">
+      <form action="#">
+        <p>Titre de la tache</p>
+        <input
+          type="text"
+          placeholder="Titre"
+          value={titre}
+          onChange={(event) => onTitreChange(event.target.value)}
+          required
+        />
+        <p>Description de la tache</p>
+        <input
+          type="text"
+          placeholder="Description"
+          value={description}
+          onChange={(event) => onDescriptionChange(event.target.value)}
+        />
+        <p>Date d'échéance</p>
+        <input
+          type="date"
+          value={dateEcheance}
+          onChange={(event) => onDateEcheanceChange(event.target.value)}
+        />
+        {titre && <button onClick={onAjouter}>Ajouter</button>}
+      </form>
+    </div>
+  );
+}

--- a/src/components/ListeTaches.tsx
+++ b/src/components/ListeTaches.tsx
@@ -1,0 +1,151 @@
+import type { Tache } from "../types/tache";
+
+type ListeTachesProps = {
+  taches: Tache[];
+  enSuppression: string[];
+  derniereTacheAjoutee: string | null;
+  idEnEdition: string | null;
+  titreEdition: string;
+  descriptionEdition: string;
+  dateEcheanceEdition: string;
+  onTitreEditionChange: (valeur: string) => void;
+  onDescriptionEditionChange: (valeur: string) => void;
+  onDateEcheanceEditionChange: (valeur: string) => void;
+  onBasculerEtat: (id: string) => void;
+  onDemarrerEdition: (tache: Tache) => void;
+  onAnnulerEdition: () => void;
+  onEnregistrerEdition: (id: string) => void;
+  onSupprimerTache: (id: string) => void;
+  onFinSuppression: (id: string, animationName?: string) => void;
+};
+
+export function ListeTaches({
+  taches,
+  enSuppression,
+  derniereTacheAjoutee,
+  idEnEdition,
+  titreEdition,
+  descriptionEdition,
+  dateEcheanceEdition,
+  onTitreEditionChange,
+  onDescriptionEditionChange,
+  onDateEcheanceEditionChange,
+  onBasculerEtat,
+  onDemarrerEdition,
+  onAnnulerEdition,
+  onEnregistrerEdition,
+  onSupprimerTache,
+  onFinSuppression,
+}: ListeTachesProps) {
+  return (
+    <ul>
+      {taches.map((tache) => (
+        <li
+          key={tache.id}
+          className={`tache-item ${tache.terminee ? "tache-terminee" : ""} ${
+            enSuppression.includes(tache.id) ? "tache-suppression" : ""
+          } ${derniereTacheAjoutee === tache.id ? "tache-ajout" : ""}`}
+          onAnimationEnd={(event) => onFinSuppression(tache.id, event.animationName)}
+        >
+          {idEnEdition === tache.id ? (
+            <div className="edition-tache">
+              <div className="edition-entete">
+                <label className="statut-tache statut-edition">
+                  <input
+                    type="checkbox"
+                    checked={tache.terminee}
+                    onChange={() => onBasculerEtat(tache.id)}
+                  />
+                  <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
+                </label>
+              </div>
+              <div className="edition-champs">
+                <label>
+                  <span>Titre</span>
+                  <input
+                    type="text"
+                    value={titreEdition}
+                    onChange={(event) => onTitreEditionChange(event.target.value)}
+                    required
+                  />
+                </label>
+                <label>
+                  <span>Description</span>
+                  <input
+                    type="text"
+                    value={descriptionEdition}
+                    onChange={(event) =>
+                      onDescriptionEditionChange(event.target.value)
+                    }
+                  />
+                </label>
+                <label>
+                  <span>Date d'échéance</span>
+                  <input
+                    type="date"
+                    value={dateEcheanceEdition}
+                    onChange={(event) =>
+                      onDateEcheanceEditionChange(event.target.value)
+                    }
+                  />
+                </label>
+              </div>
+              <div className="edition-actions">
+                <button
+                  type="button"
+                  onClick={() => onEnregistrerEdition(tache.id)}
+                  disabled={!titreEdition.trim()}
+                >
+                  Enregistrer
+                </button>
+                <button
+                  type="button"
+                  className="bouton-secondaire"
+                  onClick={onAnnulerEdition}
+                >
+                  Annuler
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="tache-en-tete">
+                <h3>{tache.titre}</h3>
+                <div className="actions-tache">
+                  <label className="statut-tache">
+                    <input
+                      type="checkbox"
+                      checked={tache.terminee}
+                      onChange={() => onBasculerEtat(tache.id)}
+                    />
+                    <span>{tache.terminee ? "Réalisée" : "À faire"}</span>
+                  </label>
+                  <button
+                    type="button"
+                    className="bouton-edition"
+                    onClick={() => onDemarrerEdition(tache)}
+                    aria-label={`Modifier la tâche ${tache.titre}`}
+                  >
+                    Modifier
+                  </button>
+                  <button
+                    type="button"
+                    className="bouton-suppression"
+                    onClick={() => onSupprimerTache(tache.id)}
+                    aria-label={`Supprimer la tâche ${tache.titre}`}
+                  >
+                    Supprimer
+                  </button>
+                </div>
+              </div>
+              <p>Description : {tache.description || "Aucune description"}</p>
+              <p className="date">
+                Date d'échéance : {tache.dateEcheance || "Non définie"}
+              </p>
+            </>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ModalConfirmation.tsx
+++ b/src/components/ModalConfirmation.tsx
@@ -1,0 +1,47 @@
+import type { Tache } from "../types/tache";
+
+type ModalConfirmationProps = {
+  tache: Tache;
+  onConfirmer: () => void;
+  onAnnuler: () => void;
+};
+
+export function ModalConfirmation({
+  tache,
+  onConfirmer,
+  onAnnuler,
+}: ModalConfirmationProps) {
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirmation-suppression-titre"
+      onClick={onAnnuler}
+    >
+      <div className="modal-content" onClick={(event) => event.stopPropagation()}>
+        <h3 id="confirmation-suppression-titre">Confirmer la suppression</h3>
+        <p>
+          Voulez-vous vraiment supprimer la tache {" "}
+          <strong>{tache.titre || "sans titre"}</strong> ?
+        </p>
+        <div className="modal-actions">
+          <button
+            type="button"
+            className="bouton-suppression"
+            onClick={onConfirmer}
+          >
+            Supprimer
+          </button>
+          <button
+            type="button"
+            className="bouton-secondaire"
+            onClick={onAnnuler}
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResumeTaches.tsx
+++ b/src/components/ResumeTaches.tsx
@@ -1,0 +1,38 @@
+type ResumeTachesProps = {
+  nombreAFaire: number;
+  nombreTerminees: number;
+  animeCompteurAFaire: boolean;
+  animeCompteurTerminees: boolean;
+};
+
+export function ResumeTaches({
+  nombreAFaire,
+  nombreTerminees,
+  animeCompteurAFaire,
+  animeCompteurTerminees,
+}: ResumeTachesProps) {
+  return (
+    <div className="resume-taches">
+      <div className="carte-resume carte-animable">
+        <span className="resume-titre">À faire</span>
+        <span
+          className={`resume-valeur ${
+            animeCompteurAFaire ? "compteur-anime" : ""
+          }`}
+        >
+          {nombreAFaire}
+        </span>
+      </div>
+      <div className="carte-resume carte-animable">
+        <span className="resume-titre">Terminées</span>
+        <span
+          className={`resume-valeur ${
+            animeCompteurTerminees ? "compteur-anime" : ""
+          }`}
+        >
+          {nombreTerminees}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/types/tache.ts
+++ b/src/types/tache.ts
@@ -1,0 +1,9 @@
+export type Tache = {
+  id: string;
+  titre: string;
+  description: string;
+  dateEcheance: string;
+  terminee: boolean;
+};
+
+export type FiltreTache = "toutes" | "aFaire" | "terminees";


### PR DESCRIPTION
## Summary
- extrait le formulaire, les filtres, la liste et le modal de confirmation dans des composants réutilisables
- centralisé les types Tache et FiltreTache et simplifié App.tsx pour orchestrer les sous-composants

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc3de6048833298747da55275b8c4