### PR TITLE
Ajout d’un champ de recherche pour les tâches

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,7 +163,8 @@ form p {
 }
 
 input[type="text"],
-input[type="date"] {
+input[type="date"],
+input[type="search"] {
   padding: 0.7em 1em;
   border: none;
   border-radius: 8px;
@@ -175,7 +176,8 @@ input[type="date"] {
   box-shadow: 0 1px 2px #00000011;
 }
 input[type="text"]:focus,
-input[type="date"]:focus {
+input[type="date"]:focus,
+input[type="search"]:focus {
   box-shadow: 0 0 0 2px #6366f1;
 }
 
@@ -199,6 +201,45 @@ button:hover {
 
 .taches-list {
   margin-top: 2.5rem;
+}
+
+.zone-controles-taches {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.recherche-taches {
+  position: relative;
+}
+
+.recherche-taches input[type="search"] {
+  width: 100%;
+  padding-right: 2.8rem;
+}
+
+.recherche-taches::after {
+  content: "🔍";
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+@media (min-width: 700px) {
+  .zone-controles-taches {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 1.2rem;
+  }
+
+  .recherche-taches {
+    flex: 1;
+  }
 }
 
 .filtres-taches {

--- a/src/components/RechercheTaches.tsx
+++ b/src/components/RechercheTaches.tsx
@@ -1,0 +1,25 @@
+import type { ChangeEvent } from "react";
+
+type RechercheTachesProps = {
+  valeur: string;
+  onRechercheChange: (valeur: string) => void;
+};
+
+export function RechercheTaches({ valeur, onRechercheChange }: RechercheTachesProps) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    onRechercheChange(event.target.value);
+  }
+
+  return (
+    <div className="recherche-taches">
+      <input
+        id="recherche-taches-input"
+        type="search"
+        value={valeur}
+        onChange={handleChange}
+        placeholder="Rechercher une tâche..."
+        aria-label="Rechercher une tâche"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé
- ajoute un champ de recherche pour filtrer les tâches par titre et description
- ajuste le message d’absence de résultats et le style des contrôles de la liste

## Tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc6d05f80833294898f860b2cd82e