### PR TITLE
Ajoute des graphiques à la page de statistiques

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -274,6 +274,163 @@ button:hover {
   font-weight: 500;
 }
 
+.stats-visualisations {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+  width: 100%;
+}
+
+.graphique-carte {
+  background: #1a1a20;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px #00000033;
+  padding: 1.5rem 1.8rem 1.8rem 1.8rem;
+  flex: 1 1 280px;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.2rem;
+  text-align: left;
+}
+
+.graphique-carte h2 {
+  width: 100%;
+  color: #e4e4e7;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.graphique-barre {
+  position: relative;
+  width: 100%;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+  box-shadow: inset 0 1px 3px #00000044;
+}
+
+.graphique-barre-segment {
+  display: block;
+  height: 100%;
+  transition: width 0.6s ease;
+}
+
+.graphique-legende {
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.graphique-legende li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: #d4d4d8;
+  font-size: 0.95rem;
+}
+
+.point-legende {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.06);
+}
+
+.legende-label {
+  flex: 1;
+}
+
+.legende-valeurs {
+  font-variant-numeric: tabular-nums;
+  color: #a5b4fc;
+  font-weight: 600;
+}
+
+.graphique-vide {
+  color: #a1a1aa;
+  margin: 0;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.graphique-donut {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  display: grid;
+  place-items: center;
+}
+
+.graphique-donut svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.donut-cercle-fond {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 12;
+}
+
+.donut-cercle-progression {
+  fill: none;
+  stroke: #818cf8;
+  stroke-linecap: round;
+  stroke-width: 12;
+  transition: stroke-dashoffset 0.8s ease;
+}
+
+.donut-valeur {
+  position: absolute;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #f8fafc;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.2rem;
+}
+
+.donut-valeur small {
+  font-size: 0.8rem;
+  color: #cbd5f5;
+  font-weight: 500;
+}
+
+.donut-texte {
+  color: #cbd5f5;
+  margin: 0;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .graphique-carte {
+    max-width: 100%;
+    padding: 1.3rem 1.2rem 1.4rem 1.2rem;
+  }
+
+  .graphique-legende li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .legende-valeurs {
+    font-size: 0.9rem;
+  }
+}
+
 .taches-list {
   margin-top: 2.5rem;
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -28,6 +28,36 @@ export function StatsPage({ total, terminees, aFaire }: StatsPageProps): ReactEl
     return "Continuez sur cette lancée pour atteindre 100 % de complétion.";
   })();
 
+  const messageProgressionDetaillee = (() => {
+    if (total === 0) {
+      return "Commencez par ajouter une tâche pour suivre votre progression.";
+    }
+    if (aFaire === 0) {
+      return "Toutes vos tâches sont finalisées, prenez le temps de savourer !";
+    }
+    return `Encore ${aFaire} tâche${aFaire > 1 ? "s" : ""} à finaliser.`;
+  })();
+
+  const repartitionTaches = [
+    {
+      id: "terminees",
+      label: "Terminées",
+      valeur: terminees,
+      couleur: "#22c55e",
+    },
+    {
+      id: "a-faire",
+      label: "À faire",
+      valeur: aFaire,
+      couleur: "#f97316",
+    },
+  ];
+
+  const rayonDonut = 52;
+  const perimetreDonut = 2 * Math.PI * rayonDonut;
+  const offsetDonut =
+    perimetreDonut - (pourcentageCompletion / 100) * perimetreDonut;
+
   return (
     <div className="page-stats">
       <h1>Statistiques de vos tâches</h1>
@@ -50,6 +80,102 @@ export function StatsPage({ total, terminees, aFaire }: StatsPageProps): ReactEl
           <span className="resume-valeur">{pourcentageAffiche} %</span>
         </div>
       </div>
+
+      <section className="stats-visualisations">
+        <article className="graphique-carte">
+          <h2>Répartition des tâches</h2>
+          {total === 0 ? (
+            <p className="graphique-vide">
+              Ajoutez des tâches pour visualiser leur répartition.
+            </p>
+          ) : (
+            <>
+              <div
+                className="graphique-barre"
+                role="img"
+                aria-label={`Répartition des tâches : ${repartitionTaches
+                  .map(
+                    (segment) =>
+                      `${segment.label} ${segment.valeur} tâche${
+                        segment.valeur > 1 ? "s" : ""
+                      }`
+                  )
+                  .join(", ")}.`}
+              >
+                {repartitionTaches.map((segment) => (
+                  <span
+                    key={segment.id}
+                    className="graphique-barre-segment"
+                    style={{
+                      width:
+                        total === 0
+                          ? "0%"
+                          : `${(segment.valeur / total) * 100}%`,
+                      backgroundColor: segment.couleur,
+                    }}
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+              <ul className="graphique-legende">
+                {repartitionTaches.map((segment) => {
+                  const pourcentageSegment =
+                    total === 0
+                      ? 0
+                      : Number(
+                          ((segment.valeur / total) * 100).toFixed(1)
+                        );
+                  const pourcentageAfficheSegment = pourcentageSegment.toLocaleString(
+                    "fr-FR",
+                    {
+                      maximumFractionDigits: 1,
+                    }
+                  );
+                  return (
+                    <li key={segment.id}>
+                      <span
+                        className="point-legende"
+                        style={{ backgroundColor: segment.couleur }}
+                        aria-hidden="true"
+                      />
+                      <span className="legende-label">{segment.label}</span>
+                      <span className="legende-valeurs">
+                        {segment.valeur} · {pourcentageAfficheSegment} %
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          )}
+        </article>
+        <article className="graphique-carte">
+          <h2>Progression globale</h2>
+          <div
+            className="graphique-donut"
+            role="img"
+            aria-label={`Progression globale : ${pourcentageAffiche} % de complétion.`}
+          >
+            <svg viewBox="0 0 120 120" aria-hidden="true">
+              <circle className="donut-cercle-fond" cx="60" cy="60" r="52" />
+              <circle
+                className="donut-cercle-progression"
+                cx="60"
+                cy="60"
+                r="52"
+                strokeDasharray={perimetreDonut}
+                strokeDashoffset={offsetDonut}
+              />
+            </svg>
+            <span className="donut-valeur">
+              {pourcentageAffiche}
+              <small>%</small>
+            </span>
+          </div>
+          <p className="donut-texte">{messageProgressionDetaillee}</p>
+        </article>
+      </section>
+
       <p className="stats-texte-conclusion">{messageConclusion}</p>
     </div>
   );


### PR DESCRIPTION
## Résumé
- ajoute un graphique en barres empilées pour visualiser la répartition des tâches
- affiche une jauge circulaire animée avec un message détaillé sur la progression globale
- applique un style dédié pour les nouvelles visualisations de la page statistiques

## Tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfca8f398483329ef8dbc3e42f6557